### PR TITLE
Fix slice indexing for large prompts

### DIFF
--- a/pkg/prompt/enhance.go
+++ b/pkg/prompt/enhance.go
@@ -67,7 +67,7 @@ func (e *Default) Enhance(prompt models.Request) (string, error) {
 	enhanced += fmt.Sprintf("<@%s>:", e.botID)
 
 	if len(enhanced) > e.maxPromptLength {
-		enhanced = string(enhanced[len(enhanced)-1-e.maxPromptLength])
+		enhanced = enhanced[len(enhanced)-1-e.maxPromptLength:]
 	}
 
 	return enhanced, nil


### PR DESCRIPTION
Large prompts are shortened to the last `maxPromptLength`th characters in a string. Bug where indexing was done incorrectly and was returning a single character at index rather than substring from index to end.

Update indexing to use substring and not single character.