### PR TITLE
Improve prompt enhancement

### DIFF
--- a/pkg/prompt/enhance.go
+++ b/pkg/prompt/enhance.go
@@ -74,7 +74,7 @@ func (e *Default) Enhance(prompt models.Request) (string, error) {
 	for _, s := range ss {
 		enhanced += s + e.separator
 	}
-	enhanced += fmt.Sprintf("[\"%s\" <@%s>]: ", bot.Name, bot.ID)
+	enhanced += fmt.Sprintf("[%s <@%s>]: ", bot.Name, bot.ID)
 
 	if len(enhanced)+len(preamble) > e.maxPromptLength {
 		enhanced = enhanced[len(enhanced)+len(preamble)-1-e.maxPromptLength:]

--- a/pkg/slackclient/slackclient.go
+++ b/pkg/slackclient/slackclient.go
@@ -11,17 +11,17 @@ import (
 )
 
 type Client struct {
-	slack *slack.Client
+	*slack.Client
 }
 
 func New(sc *slack.Client) *Client {
 	return &Client{
-		slack: sc,
+		Client: sc,
 	}
 }
 
 func (c *Client) GetChannelMessages(channel string, from, to time.Time) ([]slack.Message, error) {
-	resp, err := c.slack.GetConversationHistory(&slack.GetConversationHistoryParameters{
+	resp, err := c.GetConversationHistory(&slack.GetConversationHistoryParameters{
 		ChannelID: channel,
 		Inclusive: true,
 		Latest:    slacktime.ParseTime(to),
@@ -41,7 +41,7 @@ func (c *Client) GetChannelMessages(channel string, from, to time.Time) ([]slack
 }
 
 func (c *Client) GetThreadMessages(channel, threadTs string, from, to time.Time) ([]slack.Message, error) {
-	msgs, _, _, err := c.slack.GetConversationReplies(&slack.GetConversationRepliesParameters{
+	msgs, _, _, err := c.GetConversationReplies(&slack.GetConversationRepliesParameters{
 		ChannelID: channel,
 		Timestamp: threadTs,
 		Inclusive: true,
@@ -56,6 +56,6 @@ func (c *Client) GetThreadMessages(channel, threadTs string, from, to time.Time)
 }
 
 func (c *Client) Respond(ctx context.Context, response models.Response) error {
-	_, _, err := c.slack.PostMessage(response.SlackChannel, slack.MsgOptionTS(response.SlackThreadTS), slack.MsgOptionText(response.Completion, false))
+	_, _, err := c.PostMessage(response.SlackChannel, slack.MsgOptionTS(response.SlackThreadTS), slack.MsgOptionText(response.Completion, false))
 	return err
 }


### PR DESCRIPTION
Add preamble before messages context that should teach SlackGPT what is a name and what is a username. The same pattern is seen in name tags the prepend each message, including it's own, so should be able to call people by their name and tag them in messages.

Add separator between messages and provide separator as stop token, noticed previously sometimes would attempt to complete replies to itself.